### PR TITLE
Refactor state machine code and fix warnings

### DIFF
--- a/StateMachineTest/NwkStateMachineED.c
+++ b/StateMachineTest/NwkStateMachineED.c
@@ -11,41 +11,47 @@ extern State_t NwkSendingEDAck;
 State_t  NwkStatesED[] =
 {
 	/*NWKIDLE,							  */
-	{
-		NwkIdleEntry,
-		NwkIdleRunning,
-		NwkIdleExit
-	},
+        {
+                NwkIdleEntry,
+                NwkIdleRunning,
+                NwkIdleExit,
+                {0}
+        },
 	/*NWKSENDINGMSG,					  */
-	{
-		NwkSendingMsgEntry,
-		NwkSendingMsgRunning,
-		NwkSendingMsgExit
-	},
+        {
+                NwkSendingMsgEntry,
+                NwkSendingMsgRunning,
+                NwkSendingMsgExit,
+                {0}
+        },
 	/*NWKWAITINGFORSYNCCMDFROMGATEWAY,	  */
-	{
-		NwkWaitingForSyncCmdFromGatewayEntry,
-		NwkWaitingForSyncCmdFromGatewayRunning,
-		NwkWaitingForSyncCmdFromGatewayExit
-	},
+        {
+                NwkWaitingForSyncCmdFromGatewayEntry,
+                NwkWaitingForSyncCmdFromGatewayRunning,
+                NwkWaitingForSyncCmdFromGatewayExit,
+                {0}
+        },
 	/*NWKCHECKMSG,						  */
-	{
-		NwkCheckMsgEntry,
-		NwkCheckMsgRunning,
-		NwkCheckMsgExit
-	},
+        {
+                NwkCheckMsgEntry,
+                NwkCheckMsgRunning,
+                NwkCheckMsgExit,
+                {0}
+        },
 	/*NWKROUTEMSG,						  */
-	{
-		 NwkRouteMsgEntry,
-		 NwkRouteMsgRunning,
-		 NwkRouteMsgExit
-	},
+        {
+                 NwkRouteMsgEntry,
+                 NwkRouteMsgRunning,
+                 NwkRouteMsgExit,
+                 {0}
+        },
 	/*NWKSENDINGEDACK,				      */
-	{
-		NwkSendingEDAckEntry,
-		NwkSendingEDAckRunning,
-		NwkSendingEDAckExit
-	}
+        {
+                NwkSendingEDAckEntry,
+                NwkSendingEDAckRunning,
+                NwkSendingEDAckExit,
+                {0}
+        }
 };
 
 StateName_t NwkStateTransitionsED[NWKSTATESED_MAXNUM][NWK_EVENT_ED_MAXNUM] =
@@ -64,10 +70,10 @@ StateEventMatrix_t NwkStateMachine1 =
 {
 	/*const int stateMaxNum;				   */  NWKSTATESED_MAXNUM,
 	/*const int eventMaxNum;				   */  NWK_EVENT_ED_MAXNUM,
-	/*const void* stateMachineMemory;		   */  StateMemoryNwk1,
+	/*void* stateMachineMemory;                        */  StateMemoryNwk1,
 	/*const StateName_t startingState;		   */  NWKIDLE,
 	/*const State_t* states;				   */  NwkStatesED,
-	/*const StateName_t** stateTransitions;	   */  NwkStateTransitionsED,
+        /*const StateName_t* stateTransitions;     */  &NwkStateTransitionsED[0][0],
 	/*Events_t actualEvent;					   */  EVENT_INVALID,
 	/*StateName_t actualState;				   */  STATE_INVALID
 };
@@ -77,10 +83,10 @@ StateEventMatrix_t NwkStateMachine2 =
 {
 	/*const int stateMaxNum;				   */  NWKSTATESED_MAXNUM,
 	/*const int eventMaxNum;				   */  NWK_EVENT_ED_MAXNUM,
-	/*const void* stateMachineMemory;		   */  StateMemoryNwk2,
+	/*void* stateMachineMemory;                        */  StateMemoryNwk2,
 	/*const StateName_t startingState;		   */  NWKIDLE,
 	/*const State_t* states;				   */  NwkStatesED,
-	/*const StateName_t** stateTransitions;	   */  NwkStateTransitionsED,
+        /*const StateName_t* stateTransitions;     */  &NwkStateTransitionsED[0][0],
 	/*Events_t actualEvent;					   */  EVENT_INVALID,
 	/*StateName_t actualState;				   */  STATE_INVALID
 };
@@ -90,10 +96,11 @@ StateEventMatrix_t NwkStateMachine3 =
 {
 	/*const int stateMaxNum;				   */  NWKSTATESED_MAXNUM,
 	/*const int eventMaxNum;				   */  NWK_EVENT_ED_MAXNUM,
-	/*const void* stateMachineMemory;		   */  StateMemoryNwk3,
+	/*void* stateMachineMemory;                        */  StateMemoryNwk3,
 	/*const StateName_t startingState;		   */  NWKIDLE,
 	/*const State_t* states;				   */  NwkStatesED,
-	/*const StateName_t** stateTransitions;	   */  NwkStateTransitionsED,
+        /*const StateName_t* stateTransitions;     */  &NwkStateTransitionsED[0][0],
 	/*Events_t actualEvent;					   */  EVENT_INVALID,
 	/*StateName_t actualState;				   */  STATE_INVALID
 };
+

--- a/StateMachineTest/NwkStates.c
+++ b/StateMachineTest/NwkStates.c
@@ -2,12 +2,21 @@
 
 void* NwkIdleEntry(State_t* this, void* ptr)
 {
+        (void)this;
+        (void)ptr;
+        return 0;
 }
 void* NwkIdleRunning(State_t* this, void* ptr)
 {
+        (void)this;
+        (void)ptr;
+        return 0;
 }
 void* NwkIdleExit(State_t* this, void* ptr)
 {
+        (void)this;
+        (void)ptr;
+        return 0;
 }
 
 typedef struct {
@@ -31,92 +40,124 @@ void* NwkSendingMsgEntry(State_t* this, void* ptr)
 
 void* NwkSendingMsgRunning(State_t* this, void* ptr)
 {
-	MsgType_t* msgType = (MsgType_t*)ptr; 
-	NwkSendingMsg_t* sendingMsg = (NwkSendingMsg_t*)this->stateMemory;
+        (void)ptr;
+        NwkSendingMsg_t* sendingMsg = (NwkSendingMsg_t*)this->stateMemory;
 
-	sendingMsg->actualFrameTx++;
-	return 0;
+        sendingMsg->actualFrameTx++;
+        return 0;
 }
 void* NwkSendingMsgExit(State_t* this, void* ptr)
 {
-	MsgType_t* msgType = (MsgType_t*)ptr;
-	NwkSendingMsg_t* sendingMsg = (NwkSendingMsg_t*)this->stateMemory;
-	return 0;
+        (void)this;
+        (void)ptr;
+        return 0;
 }
 
 
 /* NwkWaitingForSyncCmdFromGateway */
 void* NwkWaitingForSyncCmdFromGatewayEntry(State_t* this, void* ptr)
 {
-	return 0;
+        (void)this;
+        (void)ptr;
+        return 0;
 }
 void* NwkWaitingForSyncCmdFromGatewayRunning(State_t* this, void* ptr)
 {
-	return 0;
+        (void)this;
+        (void)ptr;
+        return 0;
 }
 void* NwkWaitingForSyncCmdFromGatewayExit(State_t* this, void* ptr)
 {
-	return 0;
+        (void)this;
+        (void)ptr;
+        return 0;
 }
 
 /* NwkCheckMsg */
 void* NwkCheckMsgEntry(State_t* this, void* ptr)
 {
-	return 0;
+        (void)this;
+        (void)ptr;
+        return 0;
 }
 void* NwkCheckMsgRunning(State_t* this, void* ptr)
 {
-	return 0;
+        (void)this;
+        (void)ptr;
+        return 0;
 }
 void* NwkCheckMsgExit(State_t* this, void* ptr)
 {
-	return 0;
+        (void)this;
+        (void)ptr;
+        return 0;
 }
 
 
 /*  NwkRouteMsg */
 void* NwkRouteMsgEntry(State_t* this, void* ptr)
 {
-	return 0;
+        (void)this;
+        (void)ptr;
+        return 0;
 }
 void* NwkRouteMsgRunning(State_t* this, void* ptr)
 {
-	return 0;
+        (void)this;
+        (void)ptr;
+        return 0;
 }
 void* NwkRouteMsgExit(State_t* this, void* ptr)
 {
-	return 0;
+        (void)this;
+        (void)ptr;
+        return 0;
 }
 
 
 /*  NwkSendingEDAck */
 void* NwkSendingEDAckEntry(State_t* this, void* ptr)
 {
-	return 0;
+        (void)this;
+        (void)ptr;
+        return 0;
 }
 
 void* NwkSendingEDAckRunning(State_t* this, void* ptr)
 {
-	return 0;
+        (void)this;
+        (void)ptr;
+        return 0;
 }
 void* NwkSendingEDAckExit(State_t* this, void* ptr)
 {
-	return 0;
+        (void)this;
+        (void)ptr;
+        return 0;
 }
 
 /*  NwkWaitingForEDAck */
 
 void* NwkWaitingForEDAckEntry(State_t* this, void* ptr)
 {
-	return 0;
+        (void)this;
+        (void)ptr;
+        return 0;
 }
 
 void* NwkWaitingForEDAckRunning(State_t* this, void* ptr)
 {
-	return 0;
+        (void)this;
+        (void)ptr;
+        return 0;
 }
 
 void* NwkWaitingForEDAckExit(State_t* this, void* ptr)
 {
-	return 0;
+        (void)this;
+        (void)ptr;
+        return 0;
 }
+
+

--- a/StateMachineTest/State.h
+++ b/StateMachineTest/State.h
@@ -7,12 +7,12 @@
 
 typedef struct _State_t
 {
-	const void* (*entryFnc_ptr)(struct _State_t*, void*);
-	const void* (*runningFnc_ptr)(struct _State_t*, void*);
-	const void* (*exitFnc_ptr)(struct _State_t*, void*);
+void* (*entryFnc_ptr)(struct _State_t*, void*);
+void* (*runningFnc_ptr)(struct _State_t*, void*);
+void* (*exitFnc_ptr)(struct _State_t*, void*);
 
-	uint8_t stateMemory[STATE_MEMORY];
-}State_t;
+uint8_t stateMemory[STATE_MEMORY];
+} State_t;
 
 
 #endif

--- a/StateMachineTest/StateEventMatrix.c
+++ b/StateMachineTest/StateEventMatrix.c
@@ -1,34 +1,36 @@
 #include "StateEventMatrix.h"
-
+#include <string.h>
 
 void StateEventMatrix_ExecuteTrans(StateEventMatrix_t* StateMatrix)
 {
 	if (StateMatrix->actualEvent != EVENT_INVALID)
 	{
-		StateName_t* statePointers = &StateMatrix->stateTransitions[StateMatrix->actualState * StateMatrix->eventMaxNum];
-		StateName_t newState = statePointers[StateMatrix->actualEvent];
-		State_t* actualStateDesc = &StateMatrix->states[StateMatrix->actualState];
+                const StateName_t* statePointers =
+                        StateMatrix->stateTransitions +
+                        (StateMatrix->actualState * StateMatrix->eventMaxNum);
+                StateName_t newState = statePointers[StateMatrix->actualEvent];
+                State_t* actualStateDesc = &StateMatrix->states[StateMatrix->actualState];
 		if (newState != STATE_INVALID)
 		{
 			/* Exit from actual state */
-			actualStateDesc->exitFnc_ptr(
-				(State_t*)actualStateDesc,
-				(void*)StateMatrix->stateMachineMemoryBuffer);
+                        actualStateDesc->exitFnc_ptr(
+                                actualStateDesc,
+                                StateMatrix->stateMachineMemoryBuffer);
 
 			/* Enter new state */
 			StateMatrix->actualState = newState;
 			actualStateDesc = &StateMatrix->states[StateMatrix->actualState];
-			actualStateDesc->entryFnc_ptr(
-				(State_t*)actualStateDesc,
-				(void*)StateMatrix->stateMachineMemoryBuffer);
+                        actualStateDesc->entryFnc_ptr(
+                                actualStateDesc,
+                                StateMatrix->stateMachineMemoryBuffer);
 		}
 
 		/* Run the state */
-		actualStateDesc = &StateMatrix->states[StateMatrix->actualState];
-		/* Run actual state */
-		actualStateDesc->runningFnc_ptr(
-			(State_t*)actualStateDesc,
-			(void*)StateMatrix->stateMachineMemoryBuffer);
+                actualStateDesc = &StateMatrix->states[StateMatrix->actualState];
+                /* Run actual state */
+                actualStateDesc->runningFnc_ptr(
+                        actualStateDesc,
+                        StateMatrix->stateMachineMemoryBuffer);
 	}
 
 	StateMatrix->actualEvent = EVENT_INVALID;
@@ -40,7 +42,7 @@ void StateEventMatrix_Init(StateEventMatrix_t* StateMatrix)
 	StateMatrix->actualState = StateMatrix->startingState;
 }
 
-void StateEventMatrix_SetEvent(StateEventMatrix_t* StateMatrix, Events_t event, void* memBuffer, uint32_t bufferSize)
+void StateEventMatrix_SetEvent(StateEventMatrix_t* StateMatrix, Events_t event, const void* memBuffer, uint32_t bufferSize)
 {
 	StateMatrix->actualEvent = event;
 	if (memBuffer != 0)
@@ -48,3 +50,4 @@ void StateEventMatrix_SetEvent(StateEventMatrix_t* StateMatrix, Events_t event, 
 		memcpy(StateMatrix->stateMachineMemoryBuffer, memBuffer, bufferSize);
 	}
 }
+

--- a/StateMachineTest/StateEventMatrix.h
+++ b/StateMachineTest/StateEventMatrix.h
@@ -14,10 +14,10 @@ typedef struct
 {
 	const int stateMaxNum;
 	const int eventMaxNum;
-	const void* stateMachineMemoryBuffer;
+        void* stateMachineMemoryBuffer;
 	const StateName_t startingState;
 	State_t* const states;
-	const StateName_t** stateTransitions;
+        const StateName_t* stateTransitions;
 
 	Events_t actualEvent;
 	StateName_t actualState;
@@ -26,7 +26,7 @@ typedef struct
 
 void StateEventMatrix_ExecuteTrans(StateEventMatrix_t* StateMatrix);
 void StateEventMatrix_Init(StateEventMatrix_t* StateMatrix);
-void StateEventMatrix_SetEvent(StateEventMatrix_t* StateMatrix, Events_t event, void* memBuffer, uint32_t bufferSize);
+void StateEventMatrix_SetEvent(StateEventMatrix_t* StateMatrix, Events_t event, const void* memBuffer, uint32_t bufferSize);
 
 
 #endif // !1

--- a/StateMachineTest/main.c
+++ b/StateMachineTest/main.c
@@ -1,6 +1,8 @@
 #include "NwkStates.h"
 #include "StateEventMatrix.h"
-#include<stdio.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
 
 typedef struct {
 	uint32_t size;
@@ -12,20 +14,20 @@ extern StateEventMatrix_t NwkStateMachine1, NwkStateMachine2, NwkStateMachine3;
 StateEventMatrix_t* NwkStateMachines[] = { &NwkStateMachine1 , &NwkStateMachine2 , &NwkStateMachine3 };
 int main()
 {
-	int s = sizeof(State_t);
-	MsgType_t buffer;
+        MsgType_t buffer;
+        srand((unsigned)time(NULL));
 	StateEventMatrix_Init(&NwkStateMachine1);
 	StateEventMatrix_Init(&NwkStateMachine2);
 	StateEventMatrix_Init(&NwkStateMachine3);
 
-	for (int I = 0; I < sizeof(buffer.buffer); I++)
-	{
-		buffer.buffer[I] = I;
-	}
+        for (size_t I = 0; I < sizeof(buffer.buffer); I++)
+        {
+                buffer.buffer[I] = (uint8_t)I;
+        }
 
 	NwkStateMachines[0]->states[1].stateMemory[0] = 0;
 
-	StateEventMatrix_SetEvent(NwkStateMachines[0], 0, (void*)&buffer, sizeof(buffer));
+        StateEventMatrix_SetEvent(NwkStateMachines[0], 0, &buffer, sizeof(buffer));
 	StateEventMatrix_ExecuteTrans(NwkStateMachines[0]);
 
 	buffer.size = rand() % sizeof(buffer.buffer);
@@ -35,8 +37,8 @@ int main()
 
 		StateName_t preState = NwkStateMachines[actualBuffer]->actualState;
 
-		NWK_EventsED_t evt = rand() % NWK_EVENT_ED_MAXNUM;
-		StateEventMatrix_SetEvent(NwkStateMachines[actualBuffer], evt, (void*)&buffer, sizeof(buffer));
+                NWK_EventsED_t evt = rand() % NWK_EVENT_ED_MAXNUM;
+                StateEventMatrix_SetEvent(NwkStateMachines[actualBuffer], evt, &buffer, sizeof(buffer));
 		StateEventMatrix_ExecuteTrans(NwkStateMachines[actualBuffer]);
 		printf("Buffer: %d - PreState: %d - Event: %d - New State: %d\r\n",
 			actualBuffer, preState, evt, NwkStateMachines[actualBuffer]->actualState);


### PR DESCRIPTION
## Summary
- refactor state and state machine structures to remove const mismatches and allow memory updates
- zero-initialize network state definitions and flatten transition matrix pointer
- add random seeding and clean up unused parameters to compile cleanly

## Testing
- `gcc -Wall -Wextra -std=c11 StateMachineTest/*.c -o StateMachineTest/app`
- `./StateMachineTest/app | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b9f38926e4832f8475c09376e04194