### PR TITLE
Document APIs with Doxygen and note MISRA compliance

### DIFF
--- a/LowLevelRequirements.md
+++ b/LowLevelRequirements.md
@@ -1,0 +1,12 @@
+# Low Level Requirements
+
+The following requirements apply to the state machine library:
+
+1. The library shall provide a function to initialize the state machine to its starting state.
+2. The library shall provide a function to reset the state machine to the starting state and clear internal memory.
+3. The library shall provide a function to set the next event and optionally copy external data into the state machine memory.
+4. The library shall execute a transition only when a valid event is pending.
+5. Each public function shall validate input pointers before use to remain compatible with safety‑critical systems.
+6. Copying of external data into the state machine memory shall not exceed `STATE_MEMORY` bytes.
+7. Public APIs shall be documented using Doxygen comments to aid traceability.
+8. The implementation shall comply with MISRA C:2023 guidelines; discarded return values shall be explicitly cast to `void`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # State Machine Test
 
 The project demonstrates a minimal finite state machine engine designed with MISRA-C style in mind.
+All public APIs are documented with Doxygen comments and the code casts ignored return values to `void` to satisfy MISRA C:2023 Rule 17.7.
 A simple example shows three states—IDLE, WORK and DONE—with deterministic transitions driven by events.
 
 ## Building
@@ -32,12 +33,13 @@ Exiting DONE
 Entering IDLE
 Running IDLE
 PreState: 2 Event: 2 NewState: 0
+Reset to state: 0
 ```
 
 ## Project layout
 
 - `StateMachineTest/` – source files
-  - `State.h` and `StateEventMatrix.*` – generic engine
+  - `State.h` and `StateEventMatrix.*` – generic engine with initialization and reset utilities
   - `SimpleStates.*` – sample state implementations
   - `SimpleStateMachine.*` – transition table and instance
   - `main.c` – small driver executing a few transitions
@@ -45,3 +47,6 @@ PreState: 2 Event: 2 NewState: 0
 ## Notes
 
 The code is intended as a starting point for experimentation in safety-critical environments. Further verification is required before production use.
+
+The library provides `StateEventMatrix_Reset` to deterministically return the state machine to its initial state and clear internal memory, which can aid in building safety-critical applications.
+Return values from standard library functions such as `memcpy`, `memset` and `printf` are cast to `void` to document intentional discard in compliance with MISRA C:2023.

--- a/StateMachineTest/StateEventMatrix.c
+++ b/StateMachineTest/StateEventMatrix.c
@@ -1,6 +1,19 @@
+/**
+ * @file StateEventMatrix.c
+ * @brief Implementation of the state-event transition matrix engine.
+ */
+
 #include "StateEventMatrix.h"
 #include <string.h>
 
+/**
+ * @brief Execute the transition driven by the pending event.
+ *
+ * Performs exit, entry and running callbacks as required and clears
+ * the pending event on completion.
+ *
+ * @param[in,out] stateMatrix Pointer to the state machine object.
+ */
 void StateEventMatrix_ExecuteTrans(StateEventMatrix_t* stateMatrix)
 {
     if ((stateMatrix == NULL) || (stateMatrix->states == NULL) ||
@@ -48,6 +61,11 @@ void StateEventMatrix_ExecuteTrans(StateEventMatrix_t* stateMatrix)
     }
 }
 
+/**
+ * @brief Initialise the state machine to its starting state.
+ *
+ * @param[in,out] stateMatrix Pointer to the state machine object.
+ */
 void StateEventMatrix_Init(StateEventMatrix_t* stateMatrix)
 {
     if (stateMatrix != NULL)
@@ -57,6 +75,14 @@ void StateEventMatrix_Init(StateEventMatrix_t* stateMatrix)
     }
 }
 
+/**
+ * @brief Set the next event and optionally copy external data.
+ *
+ * @param[in,out] stateMatrix Pointer to the state machine object.
+ * @param[in] event Event to trigger.
+ * @param[in] memBuffer Optional pointer to data to copy.
+ * @param[in] bufferSize Size of the data in bytes.
+ */
 void StateEventMatrix_SetEvent(StateEventMatrix_t* stateMatrix, Events_t event,
                                void* memBuffer, uint32_t bufferSize)
 {
@@ -68,7 +94,27 @@ void StateEventMatrix_SetEvent(StateEventMatrix_t* stateMatrix, Events_t event,
     if ((memBuffer != NULL) && (stateMatrix->stateMachineMemoryBuffer != NULL) &&
         (bufferSize <= (uint32_t)STATE_MEMORY))
     {
-        memcpy(stateMatrix->stateMachineMemoryBuffer, memBuffer, bufferSize);
+        /* MISRA C:2023 Rule 17.7 fix: cast return value to void (TC) */
+        (void)memcpy(stateMatrix->stateMachineMemoryBuffer, memBuffer, bufferSize);
+    }
+}
+
+/**
+ * @brief Reset the state machine to the starting state and clear memory.
+ *
+ * @param[in,out] stateMatrix Pointer to the state machine object.
+ */
+void StateEventMatrix_Reset(StateEventMatrix_t* stateMatrix)
+{
+    if (stateMatrix != NULL)
+    {
+        stateMatrix->actualEvent = EVENT_INVALID;
+        stateMatrix->actualState = stateMatrix->startingState;
+        if (stateMatrix->stateMachineMemoryBuffer != NULL)
+        {
+            /* MISRA C:2023 Rule 17.7 fix: cast return value to void (TC) */
+            (void)memset(stateMatrix->stateMachineMemoryBuffer, 0, STATE_MEMORY);
+        }
     }
 }
 

--- a/StateMachineTest/StateEventMatrix.h
+++ b/StateMachineTest/StateEventMatrix.h
@@ -5,26 +5,76 @@
 #include <stddef.h>
 #include "State.h"
 
-#define EVENT_INVALID ((uint32_t)0xFFFFFFFFU)
-#define STATE_INVALID ((uint32_t)0xFFFFFFFFU)
+/** Invalid event identifier */
+#define EVENT_INVALID (UINT32_MAX)
 
+/** Invalid state identifier */
+#define STATE_INVALID (UINT32_MAX)
+
+/** Event identifier type */
 typedef uint32_t Events_t;
+
+/** State identifier type */
 typedef uint32_t StateName_t;
 
+/**
+ * @brief State-event transition matrix object.
+ *
+ * Stores the description of all states, allowed transitions and the
+ * execution context for a single instance of the state machine.
+ */
 typedef struct
 {
-    uint32_t stateMaxNum;
-    uint32_t eventMaxNum;
-    uint8_t* stateMachineMemoryBuffer;
-    StateName_t startingState;
-    State_t* states;
-    const StateName_t* stateTransitions; /* Matrix stored as 1D array */
-    Events_t actualEvent;
-    StateName_t actualState;
+    uint32_t stateMaxNum;                  /**< Number of states available */
+    uint32_t eventMaxNum;                  /**< Number of events available */
+    uint8_t* stateMachineMemoryBuffer;     /**< Working buffer for state memory */
+    StateName_t startingState;             /**< Initial state identifier */
+    State_t* states;                       /**< Array of state descriptions */
+    const StateName_t* stateTransitions;   /**< Transition matrix stored as 1D array */
+    Events_t actualEvent;                  /**< Pending event for next transition */
+    StateName_t actualState;               /**< Currently active state */
 } StateEventMatrix_t;
 
+/**
+ * @brief Execute the transition driven by the pending event.
+ *
+ * Performs exit, entry and running callbacks as required and clears
+ * the pending event on completion.
+ *
+ * @param[in,out] stateMatrix Pointer to the state machine object.
+ */
 void StateEventMatrix_ExecuteTrans(StateEventMatrix_t* stateMatrix);
+
+/**
+ * @brief Initialise the state machine to its starting state.
+ *
+ * Sets the current state and clears any pending event.
+ *
+ * @param[in,out] stateMatrix Pointer to the state machine object.
+ */
 void StateEventMatrix_Init(StateEventMatrix_t* stateMatrix);
+
+/**
+ * @brief Set the next event and optionally copy external data.
+ *
+ * External data is copied into the internal memory buffer if the
+ * pointers are valid and the size does not exceed STATE_MEMORY.
+ *
+ * @param[in,out] stateMatrix Pointer to the state machine object.
+ * @param[in] event Event to trigger.
+ * @param[in] memBuffer Optional pointer to data to copy.
+ * @param[in] bufferSize Size of the data in bytes.
+ */
 void StateEventMatrix_SetEvent(StateEventMatrix_t* stateMatrix, Events_t event, void* memBuffer, uint32_t bufferSize);
+
+/**
+ * @brief Reset the state machine to the starting state and clear memory.
+ *
+ * The internal memory buffer is zeroed. Compliance with MISRA C:2023
+ * Rule 17.7 is ensured by casting ignored return values to void.
+ *
+ * @param[in,out] stateMatrix Pointer to the state machine object.
+ */
+void StateEventMatrix_Reset(StateEventMatrix_t* stateMatrix);
 
 #endif /* STATE_EVENT_MATRIX_H */

--- a/StateMachineTest/main.c
+++ b/StateMachineTest/main.c
@@ -1,6 +1,18 @@
+/**
+ * @file main.c
+ * @brief Demonstration program for the state machine library.
+ */
+
 #include "SimpleStateMachine.h"
 #include <stdio.h>
 
+/**
+ * @brief Program entry point.
+ *
+ * Runs a sequence of transitions and demonstrates the reset feature.
+ *
+ * @return Zero on successful execution.
+ */
 int main(void)
 {
     Events_t events[] = { SIMPLE_EVENT_START, SIMPLE_EVENT_FINISH, SIMPLE_EVENT_RESET };
@@ -22,8 +34,11 @@ int main(void)
         StateName_t preState = SimpleStateMachine.actualState;
         StateEventMatrix_SetEvent(&SimpleStateMachine, events[i], NULL, 0U);
         StateEventMatrix_ExecuteTrans(&SimpleStateMachine);
-        printf("PreState: %u Event: %u NewState: %u\n", preState, events[i], SimpleStateMachine.actualState);
+        (void)printf("PreState: %u Event: %u NewState: %u\n", preState, events[i], SimpleStateMachine.actualState);
     }
+
+    StateEventMatrix_Reset(&SimpleStateMachine);
+    (void)printf("Reset to state: %u\n", SimpleStateMachine.actualState);
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- Add Doxygen-formatted comments for public API and sample driver
- Cast ignored return values to `void` to satisfy MISRA C:2023 Rule 17.7
- Expand low-level requirements and README with documentation and MISRA guidance

## Testing
- `cppcheck --enable=misra StateMachineTest/StateEventMatrix.c StateMachineTest/StateEventMatrix.h StateMachineTest/main.c` *(fails: command not found)*
- `gcc -std=c99 -Wall -Wextra StateMachineTest/main.c StateMachineTest/SimpleStates.c StateMachineTest/SimpleStateMachine.c StateMachineTest/StateEventMatrix.c -o statemachine`
- `./statemachine`


------
https://chatgpt.com/codex/tasks/task_e_68ba7dcbedc4832fbf91781b4be86f61